### PR TITLE
Fix JSON ordering in tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,14 +17,10 @@ jobs:
     - name: Run tests
       run: swift test -v
   test-linux:
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        swift: [5.3]
-    container: swift:${{ matrix.swift }}
+    runs-on: macos-latest
     steps:
     - uses: actions/checkout@v2
     - name: Build
-      run: swift build -v --enable-test-discovery
+      run: swift build -v
     - name: Run tests
       run: swift test -v --enable-test-discovery

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,10 +17,14 @@ jobs:
     - name: Run tests
       run: swift test -v
   test-linux:
-    runs-on: macos-latest
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        swift: [5.3]
+    container: swift:${{ matrix.swift }}
     steps:
     - uses: actions/checkout@v2
     - name: Build
-      run: swift build -v
+      run: swift build -v --enable-test-discovery
     - name: Run tests
       run: swift test -v --enable-test-discovery

--- a/Tests/AlchemyTests/SQL/Abstract/DatabaseEncodingTests.swift
+++ b/Tests/AlchemyTests/SQL/Abstract/DatabaseEncodingTests.swift
@@ -33,7 +33,20 @@ final class DatabaseEncodingTests: XCTestCase {
             DatabaseField(column: "belongs_to_id", value: .int(5)),
         ]
         
-        XCTAssertEqual(expectedFields, try model.fields())
+        let fields = try model.fields()
+        
+        XCTAssertEqual(fields.count, expectedFields.count)
+        
+        XCTAssertEqual(expectedFields[0], fields[0])
+        XCTAssertEqual(expectedFields[1], fields[1])
+        XCTAssertEqual(expectedFields[2], fields[2])
+        XCTAssertEqual(expectedFields[3], fields[3])
+        XCTAssertEqual(expectedFields[4], fields[4])
+        XCTAssertEqual(expectedFields[5], fields[5])
+        XCTAssertEqual(expectedFields[6], fields[6])
+        XCTAssertEqual(expectedFields[7], fields[7])
+        XCTAssertEqual(expectedFields[8], fields[8])
+        XCTAssertEqual(expectedFields[9], fields[9])
     }
     
     func testKeyMapping() throws {

--- a/Tests/AlchemyTests/SQL/Abstract/DatabaseEncodingTests.swift
+++ b/Tests/AlchemyTests/SQL/Abstract/DatabaseEncodingTests.swift
@@ -19,7 +19,7 @@ final class DatabaseEncodingTests: XCTestCase {
             belongsTo: .init(5)
         )
         
-        let jsonData = try JSONEncoder().encode(json)
+        let jsonData = try TestModel.jsonEncoder.encode(json)
         let expectedFields: [DatabaseField] = [
             DatabaseField(column: "string", value: .string("one")),
             DatabaseField(column: "int", value: .int(2)),
@@ -33,20 +33,7 @@ final class DatabaseEncodingTests: XCTestCase {
             DatabaseField(column: "belongs_to_id", value: .int(5)),
         ]
         
-        let fields = try model.fields()
-        
-        XCTAssertEqual(fields.count, expectedFields.count)
-        
-        XCTAssertEqual(expectedFields[0], fields[0])
-        XCTAssertEqual(expectedFields[1], fields[1])
-        XCTAssertEqual(expectedFields[2], fields[2])
-        XCTAssertEqual(expectedFields[3], fields[3])
-        XCTAssertEqual(expectedFields[4], fields[4])
-        XCTAssertEqual(expectedFields[5], fields[5])
-        XCTAssertEqual(expectedFields[6], fields[6])
-        XCTAssertEqual(expectedFields[7], fields[7])
-        XCTAssertEqual(expectedFields[8], fields[8])
-        XCTAssertEqual(expectedFields[9], fields[9])
+        XCTAssertEqual(expectedFields, try model.fields())
     }
     
     func testKeyMapping() throws {
@@ -105,6 +92,12 @@ private struct TestModel: Model {
     
     @HasMany(to: \.$belongsTo)
     var hasMany: [TestModel]
+    
+    static var jsonEncoder: JSONEncoder = {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys]
+        return encoder
+    }()
 }
 
 private struct CustomKeyedModel: Model {


### PR DESCRIPTION
Since it seems that the JSONEncoder output order is different on Linux than macOS.