### PR TITLE
Add argument label in HTTPError example 📖

### DIFF
--- a/Docs/1a_Architecture.md
+++ b/Docs/1a_Architecture.md
@@ -32,7 +32,7 @@ func someHandler() -> EventLoopFuture<String> {
 }
 
 func unimplementedHandler() -> EventLoopFuture<String> {
-    .new(error: HTTPError(.notImplemented, "This endpoint isn't implemented yet"))
+    .new(error: HTTPError(.notImplemented, message: "This endpoint isn't implemented yet"))
 }
 ```
 


### PR DESCRIPTION
It seems like the `HTTPError` init was changed after this code-snippet has been added. It now requires a "message" argument label, which this PR adds to the snippet.