### PR TITLE
Use static var in Services extension example 📖

### DIFF
--- a/Docs/2_Fusion.md
+++ b/Docs/2_Fusion.md
@@ -217,7 +217,7 @@ let eventLoopGroup = Services.eventLoopGroup
 You may also add custom static properties to it at your own convenience:
 ```swift
 extension Services {
-    var someType: SomeType {
+    static var someType: SomeType {
         Container.global.resolve(SomeType.self)
     }
 }


### PR DESCRIPTION
The docs recommend adding "custom static properties", but the code snippet described how to add a non-static property to `Services`.