### PR TITLE
Update controller example to use Request type 📖

### DIFF
--- a/Docs/3a_RoutingBasics.md
+++ b/Docs/3a_RoutingBasics.md
@@ -111,15 +111,15 @@ struct UserController: Controller {
             .post("/login", handler: controller.login)
     }
 
-    func create(req: HTTPRequest) -> String {
+    func create(req: Request) -> String {
         "Greetings from user create!"
     }
 
-    func reset(req: HTTPRequest) -> String {
+    func reset(req: Request) -> String {
         "Howdy from user reset!"
     }
 
-    func login(req: HTTPRequest) -> String {
+    func login(req: Request) -> String {
         "Yo from user login!"
     }
 }


### PR DESCRIPTION
The controller example snippet showed the request argument being of type `HTTPRequest` instead of `Request`.