### PR TITLE
Add grouping of routes by path prefix

### DIFF
--- a/Sources/Alchemy/Routing/Application+GroupedRoutes.swift
+++ b/Sources/Alchemy/Routing/Application+GroupedRoutes.swift
@@ -1,0 +1,20 @@
+extension Application {
+    /// Groups a set of endpoints by a path prefix.
+    /// All endpoints added in the `configure` closure will
+    /// be prefixed, but none in the handler chain that continues
+    /// after the `.grouped`.
+    ///
+    /// - Parameters:
+    ///   - pathPrefix: The path prefix for all routes
+    ///     defined in the `configure` closure.
+    ///   - configure: A closure for adding routes that will be
+    ///     prefixed by the given path prefix.
+    /// - Returns: This application for chaining handlers.
+    @discardableResult
+    public func grouped(_ pathPrefix: String, configure: (Application) -> Void) -> Self {
+        Services.router.pathPrefixes.append(pathPrefix)
+        configure(self)
+        _ = Services.router.pathPrefixes.popLast()
+        return self
+    }
+}

--- a/Sources/Alchemy/Routing/Router.swift
+++ b/Sources/Alchemy/Routing/Router.swift
@@ -22,6 +22,8 @@ public final class Router {
     
     /// Current middleware of this router.
     var middlewares: [Middleware] = []
+
+    var pathPrefixes: [String] = []
     
     /// A trie that holds all the handlers.
     private let trie = RouterTrieNode<HTTPMethod, RouterHandler>()
@@ -42,7 +44,8 @@ public final class Router {
         for method: HTTPMethod,
         path: String
     ) {
-        let splitPath = path.split(separator: "/").map(String.init)
+        let pathPrefixes = self.pathPrefixes.map { $0.hasPrefix("/") ? String($0.dropFirst()) : $0 }
+        let splitPath = pathPrefixes + path.split(separator: "/").map(String.init)
         let middlewareClosures = self.middlewares.reversed().map(Middleware.intercept)
         self.trie.insert(path: splitPath, storageKey: method) {
             var next = { request in


### PR DESCRIPTION
As [discussed here](https://github.com/alchemy-swift/alchemy/discussions/57), this PR adds the ability to group requests by path prefix.