### PR TITLE
Pluralize `Model.tableName` by default

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -25,6 +25,7 @@ let package = Package(
         .package(url: "https://github.com/alchemy-swift/cron.git", from: "2.3.2"),
         .package(url: "https://github.com/johnsundell/Plot.git", from: "0.8.0"),
         .package(url: "https://github.com/Mordil/RediStack.git", from: "1.0.0"),
+        .package(url: "https://github.com/mattt/InflectorKit", from: "1.0.0"),
     ],
     targets: [
         .target(
@@ -46,6 +47,7 @@ let package = Package(
                 .product(name: "Papyrus", package: "papyrus"),
                 .product(name: "Fusion", package: "fusion"),
                 .product(name: "Cron", package: "cron"),
+                .product(name: "InflectorKit", package: "InflectorKit"),
                 
                 /// Internal dependencies
                 "CAlchemy",

--- a/Package.swift
+++ b/Package.swift
@@ -23,9 +23,9 @@ let package = Package(
         .package(url: "https://github.com/alchemy-swift/papyrus", from: "0.1.0"),
         .package(url: "https://github.com/alchemy-swift/fusion", from: "0.1.0"),
         .package(url: "https://github.com/alchemy-swift/cron.git", from: "2.3.2"),
+        .package(url: "https://github.com/alchemy-swift/pluralize", from: "1.0.1"),
         .package(url: "https://github.com/johnsundell/Plot.git", from: "0.8.0"),
         .package(url: "https://github.com/Mordil/RediStack.git", from: "1.0.0"),
-        .package(url: "https://github.com/mattt/InflectorKit", from: "1.0.0"),
     ],
     targets: [
         .target(
@@ -47,7 +47,7 @@ let package = Package(
                 .product(name: "Papyrus", package: "papyrus"),
                 .product(name: "Fusion", package: "fusion"),
                 .product(name: "Cron", package: "cron"),
-                .product(name: "InflectorKit", package: "InflectorKit"),
+                .product(name: "Pluralize", package: "pluralize"),
                 
                 /// Internal dependencies
                 "CAlchemy",

--- a/Sources/Alchemy/Rune/Model/Model.swift
+++ b/Sources/Alchemy/Rune/Model/Model.swift
@@ -1,4 +1,5 @@
 import Foundation
+import InflectorKit
 
 /// An ActiveRecord-esque type used for modeling a table in a
 /// relational database. Contains many extensions for making
@@ -18,8 +19,8 @@ public protocol Model: Identifiable, ModelMaybeOptional {
     var id: Self.Identifier? { get set }
     
     /// The table with which this object is associated. Defaults to
-    /// `String(describing: Self.self)` aka the name of the type. Can
-    /// be overridden for custom table names.
+    /// the type name, pluralized. Affected by `keyMapping`. This
+    /// can be overridden for custom table names.
     ///
     /// ```swift
     /// struct User: Model {
@@ -72,7 +73,9 @@ public protocol Model: Identifiable, ModelMaybeOptional {
 
 extension Model {
     public static var tableName: String {
-        String(describing: Self.self)
+        let typeName = String(describing: Self.self)
+        let mapped = keyMapping.map(input: typeName)
+        return mapped.pluralized
     }
     
     public static var keyMapping: DatabaseKeyMapping {

--- a/Sources/Alchemy/Rune/Model/Model.swift
+++ b/Sources/Alchemy/Rune/Model/Model.swift
@@ -1,5 +1,5 @@
 import Foundation
-import InflectorKit
+import Pluralize
 
 /// An ActiveRecord-esque type used for modeling a table in a
 /// relational database. Contains many extensions for making

--- a/Tests/AlchemyTests/SQL/Abstract/DatabaseEncodingTests.swift
+++ b/Tests/AlchemyTests/SQL/Abstract/DatabaseEncodingTests.swift
@@ -35,12 +35,14 @@ final class DatabaseEncodingTests: XCTestCase {
             DatabaseField(column: "belongs_to_id", value: .int(5)),
         ]
         
+        XCTAssertEqual("test_models", TestModel.tableName)
         XCTAssertEqual(expectedFields, try model.fields())
     }
     
     func testKeyMapping() throws {
         let model = CustomKeyedModel(belongsTo: .init(9))
         let fields = try model.fields()
+        XCTAssertEqual("CustomKeyedModels", CustomKeyedModel.tableName)
         XCTAssertEqual([
             "val1",
             "valueTwo",
@@ -57,6 +59,8 @@ final class DatabaseEncodingTests: XCTestCase {
         let expectedFields: [DatabaseField] = [
             DatabaseField(column: "json", value: .json(jsonData))
         ]
+        
+        XCTAssertEqual("custom_decoder_models", CustomDecoderModel.tableName)
         XCTAssertEqual(expectedFields, try model.fields())
     }
 }


### PR DESCRIPTION
i.e. `User` -> `Users`, `UserToken` -> `UserTokens`, etc.

Also applies `keyMapping` to the type name, before pluralization.