### PR TITLE
Adds support for TLS & HTTP/2

### DIFF
--- a/Docs/1_Configuration.md
+++ b/Docs/1_Configuration.md
@@ -119,6 +119,32 @@ You can load your environment from another location by passing your app the `--e
 
 If you have separate environment variables for different server configurations (i.e. local dev, staging, production), you can pass your program a separate `--env` for each configuration so the right environment is loaded.
 
+## Configuring Your Server
+
+There are a couple of options available for configuring how your server is running. By default, the server runs over `HTTP/1.1`. 
+
+### Enable TLS
+
+You can enable running over TLS with `useHTTPS`.
+
+```swift
+func boot() throws {
+    try useHTTPS(key: "/path/to/private-key.pem", cert: "/path/to/cert.pem")
+}
+```
+
+### Enable HTTP/2
+
+You may also configure your server with `HTTP/2` upgrades (will prefer `HTTP/2` but still accept `HTTP/1.1` over TLS). To do this use `useHTTP2`.
+
+```swift
+func boot() throws {
+    try useHTTP2(key: "/path/to/private-key.pem", cert: "/path/to/cert.pem")
+}
+```
+
+Note that the `HTTP/2` protocol is only supported over TLS, and so implies using it. Thus, there's no need to call both `useHTTPS` and `useHTTP2`; `useHTTP2` sets up both TLS and `HTTP/2` support.
+
 ## Working with Xcode
 
 You can use Xcode to run your project to take advantage of all the great tools built into it; debugging, breakpoints, memory graphs, testing, etc.

--- a/Package.swift
+++ b/Package.swift
@@ -13,6 +13,8 @@ let package = Package(
     dependencies: [
         .package(url: "https://github.com/apple/swift-log.git", from: "1.0.0"),
         .package(url: "https://github.com/apple/swift-nio.git", from: "2.0.0"),
+        .package(url: "https://github.com/apple/swift-nio-ssl.git", from: "2.6.0"),
+        .package(url: "https://github.com/apple/swift-nio-http2.git", from: "1.9.0"),
         .package(url: "https://github.com/apple/swift-argument-parser", .upToNextMinor(from: "0.3.0")),
         .package(url: "https://github.com/vapor/postgres-nio.git", from: "1.1.0"),
         .package(url: "https://github.com/vapor/mysql-nio.git", from: "1.3.0"),
@@ -40,6 +42,8 @@ let package = Package(
                 .product(name: "MySQLNIO", package: "mysql-nio"),
                 .product(name: "NIO", package: "swift-nio"),
                 .product(name: "NIOHTTP1", package: "swift-nio"),
+                .product(name: "NIOHTTP2", package: "swift-nio-http2"),
+                .product(name: "NIOSSL", package: "swift-nio-ssl"),
                 .product(name: "Logging", package: "swift-log"),
                 .product(name: "Plot", package: "Plot"),
                 .product(name: "LifecycleNIOCompat", package: "swift-service-lifecycle"),

--- a/Sources/Alchemy/Application/Application+Configuration.swift
+++ b/Sources/Alchemy/Application/Application+Configuration.swift
@@ -1,0 +1,56 @@
+import NIOSSL
+
+/// Settings for how this server should talk to clients.
+public final class ApplicationConfiguration: Service {
+    /// Any TLS configuration for serving over HTTPS.
+    public var tlsConfig: TLSConfiguration?
+    /// The HTTP protocol versions supported. Defaults to `HTTP/1.1`.
+    public var httpVersions: [HTTPVersion] = [.http1_1]
+}
+
+extension Application {
+    /// Use HTTPS when serving.
+    ///
+    /// - Parameters:
+    ///   - key: The path to the private key.
+    ///   - cert: The path of the cert.
+    /// - Throws: Any errors encountered when accessing the certs.
+    public func useHTTPS(key: String, cert: String) throws {
+        let config = Container.resolve(ApplicationConfiguration.self)
+        config.tlsConfig = TLSConfiguration
+            .makeServerConfiguration(
+                certificateChain: try NIOSSLCertificate
+                    .fromPEMFile(cert)
+                    .map { NIOSSLCertificateSource.certificate($0) },
+                privateKey: .file(key))
+    }
+    
+    /// Use HTTPS when serving.
+    ///
+    /// - Parameter tlsConfig: A raw NIO `TLSConfiguration` to use.
+    public func useHTTPS(tlsConfig: TLSConfiguration) {
+        let config = Container.resolve(ApplicationConfiguration.self)
+        config.tlsConfig = tlsConfig
+    }
+    
+    /// Use HTTP/2 when serving, over TLS with the given key and cert.
+    ///
+    /// - Parameters:
+    ///   - key: The path to the private key.
+    ///   - cert: The path of the cert.
+    /// - Throws: Any errors encountered when accessing the certs.
+    public func useHTTP2(key: String, cert: String) throws {
+        let config = Container.resolve(ApplicationConfiguration.self)
+        config.httpVersions = [.http2, .http1_1]
+        try useHTTPS(key: key, cert: cert)
+    }
+    
+    /// Use HTTP/2 when serving, over TLS with the given tls config.
+    ///
+    /// - Parameter tlsConfig: A raw NIO `TLSConfiguration` to use.
+    public func useHTTP2(tlsConfig: TLSConfiguration) {
+        let config = Container.resolve(ApplicationConfiguration.self)
+        config.httpVersions = [.http2, .http1_1]
+        useHTTPS(tlsConfig: tlsConfig)
+    }
+}

--- a/Sources/Alchemy/Application/Application+Launch.swift
+++ b/Sources/Alchemy/Application/Application+Launch.swift
@@ -39,7 +39,7 @@ extension Application {
         bootServices()
         
         // Boot the app
-        boot()
+        try boot()
         
         // Register the runner
         runner.register(lifecycle: lifecycle)

--- a/Sources/Alchemy/Application/Application+Services.swift
+++ b/Sources/Alchemy/Application/Application+Services.swift
@@ -7,6 +7,7 @@ extension Application {
         Loop.config()
         
         // Register all services
+        ApplicationConfiguration.config(default: ApplicationConfiguration())
         Router.config(default: Router())
         Scheduler.config(default: Scheduler())
         NIOThreadPool.config(default: NIOThreadPool(numberOfThreads: System.coreCount))

--- a/Sources/Alchemy/Application/Application.swift
+++ b/Sources/Alchemy/Application/Application.swift
@@ -18,7 +18,7 @@ public protocol Application {
     /// environment is loaded and the global `EventLoopGroup` is
     /// set. Called on an event loop, so `Loop.current` is
     /// available for use if needed.
-    func boot()
+    func boot() throws
     
     /// Required empty initializer.
     init()

--- a/Sources/Alchemy/Commands/HTTPHandler.swift
+++ b/Sources/Alchemy/Commands/HTTPHandler.swift
@@ -86,7 +86,7 @@ final class HTTPHandler: ChannelInboundHandler {
             self.request = nil
       
             // Writes the response when done
-            self.writeResponse(response, to: context)
+            self.writeResponse(version: request.head.version, response: response, to: context)
         }
     }
   
@@ -94,14 +94,15 @@ final class HTTPHandler: ChannelInboundHandler {
     /// `ChannelHandlerContext`.
     ///
     /// - Parameters:
+    ///   - version: The HTTP version of the connection.
     ///   - response: The reponse to write to the handler context.
     ///   - context: The context to write to.
     /// - Returns: An future that completes when the response is
     ///   written.
     @discardableResult
-    private func writeResponse(_ responseFuture: EventLoopFuture<Response>, to context: ChannelHandlerContext) -> EventLoopFuture<Void> {
-        return responseFuture.flatMap { response in
-            let responseWriter = HTTPResponseWriter(handler: self, context: context)
+    private func writeResponse(version: HTTPVersion, response: EventLoopFuture<Response>, to context: ChannelHandlerContext) -> EventLoopFuture<Void> {
+        return response.flatMap { response in
+            let responseWriter = HTTPResponseWriter(version: version, handler: self, context: context)
             responseWriter.completionPromise.futureResult.whenComplete { _ in
                 if !self.keepAlive {
                     context.close(promise: nil)
@@ -124,11 +125,11 @@ final class HTTPHandler: ChannelInboundHandler {
 /// Used for writing a response to a remote peer with an
 /// `HTTPHandler`.
 private struct HTTPResponseWriter: ResponseWriter {
-    /// The HTTP version we're working with.
-    static private var httpVersion: HTTPVersion { HTTPVersion(major: 1, minor: 1) }
-    
     /// A promise to hook into for when the writing is finished.
     let completionPromise: EventLoopPromise<Void>
+
+    /// The HTTP version we're working with.
+    private var version: HTTPVersion
     
     /// The handler in which this writer is writing.
     private let handler: HTTPHandler
@@ -138,10 +139,12 @@ private struct HTTPResponseWriter: ResponseWriter {
     
     /// Initialize
     /// - Parameters:
+    ///   - version: The HTTPVersion of this connection.
     ///   - handler: The handler in which this response is writing
     ///     inside.
     ///   - context: The context to write responses to.
-    init(handler: HTTPHandler, context: ChannelHandlerContext) {
+    init(version: HTTPVersion, handler: HTTPHandler, context: ChannelHandlerContext) {
+        self.version = version
         self.handler = handler
         self.context = context
         self.completionPromise = context.eventLoop.makePromise()
@@ -150,7 +153,6 @@ private struct HTTPResponseWriter: ResponseWriter {
     // MARK: ResponseWriter
     
     func writeHead(status: HTTPResponseStatus, _ headers: HTTPHeaders) {
-        let version = HTTPResponseWriter.httpVersion
         let head = HTTPResponseHead(version: version, status: status, headers: headers)
         context.write(handler.wrapOutboundOut(.head(head)), promise: nil)
     }

--- a/Sources/Alchemy/Commands/ServeCommand.swift
+++ b/Sources/Alchemy/Commands/ServeCommand.swift
@@ -143,7 +143,13 @@ extension ChannelPipeline {
     /// - Returns: A future that completes when the config completes.
     fileprivate func addAnyTLS() -> EventLoopFuture<Void> {
         let config = Container.resolve(ApplicationConfiguration.self)
-        if let tls = config.tlsConfig {
+        if var tls = config.tlsConfig {
+            if config.httpVersions.contains(.http2) {
+                tls.applicationProtocols.append("h2")
+            }
+            if config.httpVersions.contains(.http1_1) {
+                tls.applicationProtocols.append("http/1.1")
+            }
             let sslContext = try! NIOSSLContext(configuration: tls)
             let sslHandler = NIOSSLServerHandler(context: sslContext)
             return addHandler(sslHandler)

--- a/Sources/Alchemy/HTTP/Response.swift
+++ b/Sources/Alchemy/HTTP/Response.swift
@@ -88,8 +88,8 @@ public final class Response {
     /// - Parameter writer: An abstraction around writing data to a
     ///   remote peer.
     private func defaultWriterClosure(writer: ResponseWriter) {
-        writer.writeHead(status: self.status, self.headers)
-        if let body = self.body {
+        writer.writeHead(status: status, headers)
+        if let body = body {
             writer.writeBody(body.buffer)
         }
         writer.writeEnd()
@@ -120,11 +120,4 @@ public protocol ResponseWriter {
     /// Write the end of the response. Needs to be called once per
     /// response, when all data has been written.
     func writeEnd()
-}
-
-extension ResponseWriter {
-    // Convenience default parameters for `writeHead`.
-    public func writeHead(status: HTTPResponseStatus = .ok, _ headers: HTTPHeaders = HTTPHeaders()) {
-        self.writeHead(status: status, headers)
-    }
 }


### PR DESCRIPTION
By default, the server runs over `HTTP/1.1`. 

## Enable TLS

To enable running `HTTP/1.1` over TLS, use `useHTTPS`.

```swift
func boot() throws {
    try useHTTPS(key: "/path/to/private-key.pem", cert: "/path/to/cert.pem")
}
```

## Enable HTTP/2

To enable `HTTP/2` upgrades (will prefer `HTTP/2` but still accept `HTTP/1.1` over TLS), use `useHTTP2`.

```swift
func boot() throws {
    try useHTTP2(key: "/path/to/private-key.pem", cert: "/path/to/cert.pem")
}
```

Note that the `HTTP/2` protocol is only supported over TLS, so implies using it. Thus, there's no need to call both `useHTTPS` and `useHTTP2`; `useHTTP2` sets up both TLS and `HTTP/2` support.